### PR TITLE
Omit initialValues prop being passed to <div>.

### DIFF
--- a/form.js
+++ b/form.js
@@ -85,7 +85,7 @@ export default class Form extends React.Component {
   }
 
   render() {
-    let { children, rules, ...props } = this.props;
+    let { children, rules, initialValues, ...props } = this.props;
     return <div {...props}>{this.renderChildren(children)}</div>;
   }
 }


### PR DESCRIPTION
Right now the `initialValues` prop that is used for setting the `Form` component state is also passed to the wrapping `<div>` in the render call, React produces a warning `initialValues is not a recognized prop value on the <div> tag`.

PR uses destructuring so that it isn't passed as a prop to the <div>