### PR TITLE
Add test case to catch bug where onClick is not defined

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -23,7 +23,7 @@ export default class Form extends React.Component {
       return this.setState({ errors: runner.errors.errors });
     } else this.setState({ errors: {} });
 
-    return onClick(values);
+    if (onClick) return onClick(values);
   }
 
   validateOnBlurOrChange(name, onChange) {

--- a/src/form.js
+++ b/src/form.js
@@ -13,7 +13,7 @@ export default class Form extends React.Component {
 
   validate(onClick) {
     let { rules, errorMessages = {}, attributeNames = {} } = this.props;
-    let { values } = this.state;
+    let values = { ...this.props.values, ...this.state.values };
     if (!rules) {
       if (onClick) return onClick(values);
       return;

--- a/src/form.js
+++ b/src/form.js
@@ -14,7 +14,10 @@ export default class Form extends React.Component {
   validate(onClick) {
     let { rules, errorMessages = {}, attributeNames = {} } = this.props;
     let { values } = this.state;
-    if (!rules) return onClick(values);
+    if (!rules) {
+      if (onClick) return onClick(values);
+      return;
+    }
 
     const runner = new Validator(values, rules, errorMessages);
     runner.setAttributeNames(attributeNames);

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { spy } from 'sinon';
 import Form from '../src/form';
+import { spy } from 'sinon';
 import { shallow } from 'enzyme';
 
 const Input = ({ error, ...props }) =>
@@ -140,6 +141,17 @@ test('Form validates with valid initial values passed', () => {
   spy.mockClear();
 });
 
+test('Form validates with valid initial values passed and onValues prop passed', () => {
+  const onValues = spy();
+  const wrapper = shallow(
+    <Form
+      rules={{ Awesome: 'required' }}
+      values={{ Awesome: 'hello' }}
+      onValues={onValues}
+    >
+      <Input name="Awesome" />
+      <div className="submit" submit />
+    </Form>
   );
   wrapper.find('.submit').simulate('click');
   expect(wrapper.find(Input).props().error).toEqual('');

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -108,3 +108,14 @@ test('Error is removed onChange if set before blurred', () => {
   expect(wrapper.find(Input).props().error).toEqual('');
   expect(wrapper.find(Input).props().value).toEqual('fail');
 });
+
+test('Form validates with valid initial values passed', () => {
+  const wrapper = shallow(
+    <Form rules={{ Awesome: 'required' }} values={{ Awesome: 'hello' }}>
+      <Input name="Awesome" />
+      <div className="submit" submit />
+    </Form>,
+  );
+  wrapper.find('.submit').simulate('click');
+  expect(wrapper.find(Input).props().error).toEqual('');
+});

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -1,5 +1,6 @@
 //Test that components with the prop `name` get passed errors and values
 import React from 'react';
+import { spy } from 'sinon';
 import Form from '../src/form';
 import { shallow } from 'enzyme';
 
@@ -109,12 +110,36 @@ test('Error is removed onChange if set before blurred', () => {
   expect(wrapper.find(Input).props().value).toEqual('fail');
 });
 
+test('Form doesnt run validate with no rules', () => {
+  const spy = jest.spyOn(Form.prototype, 'validate');
+  const wrapper = shallow(
+    <Form values={{ Awesome: 'hello' }}>
+      <Input name="Awesome" />
+      <div className="submit" submit />
+    </Form>
+  );
+  wrapper.find('.submit').simulate('click');
+  expect(wrapper.find(Input).props().error).toEqual('');
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.calls[0][0]).toEqual(undefined);
+  spy.mockClear();
+});
+
 test('Form validates with valid initial values passed', () => {
+  const spy = jest.spyOn(Form.prototype, 'validate');
   const wrapper = shallow(
     <Form rules={{ Awesome: 'required' }} values={{ Awesome: 'hello' }}>
       <Input name="Awesome" />
       <div className="submit" submit />
-    </Form>,
+    </Form>
+  );
+  wrapper.find('.submit').simulate('click');
+  expect(wrapper.find(Input).props().error).toEqual('');
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.calls[0][0]).toEqual(undefined);
+  spy.mockClear();
+});
+
   );
   wrapper.find('.submit').simulate('click');
   expect(wrapper.find(Input).props().error).toEqual('');


### PR DESCRIPTION
When the `submit` prop doesn't have an onClick handler the `validate` will throw an error that `onClick` is undefined.

Added a conditional check before calling `onClick` in the `validate` function to fix.

The bug is introduced in this line

```jsx
onClick: () => this.validate(child.props.onClick),
```

And `validate` assumes that `child.props.onClick !== undefined`