### PR TITLE
Fix initial values validate failing

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -13,7 +13,7 @@ export default class Form extends React.Component {
 
   validate(onClick) {
     let { rules, errorMessages = {}, attributeNames = {} } = this.props;
-    let { values } = this.state;
+    let values = { ...this.props.values, ...this.state.values };
     if (!rules) return onClick(values);
 
     const runner = new Validator(values, rules, errorMessages);

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -108,3 +108,19 @@ test('Error is removed onChange if set before blurred', () => {
   expect(wrapper.find(Input).props().error).toEqual('');
   expect(wrapper.find(Input).props().value).toEqual('fail');
 });
+
+test('Form validates with valid initial values passed and onValues prop passed', () => {
+  const onValues = jest.fn();
+  const wrapper = shallow(
+    <Form
+      rules={{ Awesome: 'required' }}
+      values={{ Awesome: 'hello' }}
+      onValues={onValues}
+    >
+      <Input name="Awesome" />
+      <div className="submit" submit onClick={() => true} />
+    </Form>
+  );
+  wrapper.find('.submit').simulate('click');
+  expect(wrapper.find(Input).props().error).toEqual('');
+});

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -1,5 +1,6 @@
 //Test that components with the prop `name` get passed errors and values
 import React from 'react';
+import { spy } from 'sinon';
 import Form from '../src/form';
 import { shallow } from 'enzyme';
 
@@ -110,7 +111,7 @@ test('Error is removed onChange if set before blurred', () => {
 });
 
 test('Form validates with valid initial values passed and onValues prop passed', () => {
-  const onValues = jest.fn();
+  const onValues = spy();
   const wrapper = shallow(
     <Form
       rules={{ Awesome: 'required' }}
@@ -118,9 +119,11 @@ test('Form validates with valid initial values passed and onValues prop passed',
       onValues={onValues}
     >
       <Input name="Awesome" />
-      <div className="submit" submit onClick={() => true} />
+      <div className="submit" submit onClick={values => onValues(values)} />
     </Form>
   );
   wrapper.find('.submit').simulate('click');
   expect(wrapper.find(Input).props().error).toEqual('');
+  expect(onValues.calledOnce).toEqual(true);
+  expect(onValues.args[0][0].Awesome).toEqual('hello');
 });


### PR DESCRIPTION
Fix bug where validate would only check against state causing validate to fail when form is initialized with valid values as props