### PR TITLE
Add onError prop

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Input from './input';
 import Submit from './submit';
 import Validator from 'validatorjs';
 import GetChildren from './get-children';
 
 export default class Form extends React.Component {
+
   constructor({ values = {}, onValues }) {
     super();
     this.state = { values: onValues ? {} : values, errors: {} };
@@ -22,8 +24,12 @@ export default class Form extends React.Component {
     runner.setAttributeNames(attributeNames);
 
     if (runner.fails()) {
+      this.props.onError(runner.errors.errors);
       return this.setState({ errors: runner.errors.errors });
-    } else this.setState({ errors: {} });
+    } else {
+      this.props.onError({});
+      this.setState({ errors: {} });
+    }
 
     return onClick(values);
   }
@@ -93,4 +99,12 @@ export default class Form extends React.Component {
     } = this.props;
     return <div {...props}>{this.renderChildren(children)}</div>;
   }
+}
+
+Form.defaultProps = {
+  onError: () => {}
+}
+
+Form.propTypes = {
+  onError: PropTypes.func
 }

--- a/tests/submit.js
+++ b/tests/submit.js
@@ -1,7 +1,7 @@
 //Tests related to the submit prop
 import React from 'react';
 import Form from '../src/form';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 const Input = ({ error, ...props }) =>
   error

--- a/tests/submit.js
+++ b/tests/submit.js
@@ -1,7 +1,7 @@
 //Tests related to the submit prop
 import React from 'react';
 import Form from '../src/form';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 const Input = ({ error, ...props }) =>
   error
@@ -62,4 +62,22 @@ test('Submit skips validation if no rules', () => {
 
   wrapper.find('.submit').simulate('click');
   expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test('Submit calls onError prop function', () => {
+
+  let onError = jest.fn();
+
+  const wrapper = shallow(
+    <Form rules={{ test: 'required|min:8' }} onError={onError}>
+      <Input name="test" />
+      <div submit className="submit" />
+    </Form>
+  );
+
+  wrapper.find('.submit').simulate('click');
+
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect( onError.mock.calls[0][0].test ).toEqual( ['The test field is required.'] );
+
 });


### PR DESCRIPTION
## TL;DR
By providing an onError prop a developer will gain control over what to do with the errors. 

## User case
In my case I bypass the `submit` and calls the validation directly using ref on a click that isn't a child of `Form`. However since I'm not able to get the internal state of `Form` I need some sort of way of accessing the information.

Other cases could be to show the errors in toasts, modals and other components that aren't child of `Form`.

My solution is to implement a `onError` that calls when the runner fails or passes within the `validator` function. Is simple and provides more flexibility.

Please consider and discuss my solution.