### PR TITLE
Trigger the onChange handler on the input component if specified

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -18,13 +18,15 @@ const getValue = (type, rawValue) => {
 };
 
 export default (child, values, children, errors, component) => {
-  let { name, onKeyUp, onEnter, type } = child.props;
+  let { name, onKeyUp, onEnter, onChange: _onChange, type } = child.props;
   return React.cloneElement(child, {
     children,
-    onChange: e =>
+    onChange: e => {
+      if (_onChange) { _onChange(e) }
       component.validateOnBlurOrChange(name, e.target.value, () =>
         component.onChange(e)
-      ),
+      )
+    },
     onBlur: e => component.validateOnBlurOrChange(name, e.target.value),
     error: getError(errors, name),
     value: getValue(type, values[name]),

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -139,3 +139,19 @@ test('Form validates with valid initial values passed and onValues prop passed',
   expect(onValues).toHaveBeenCalledTimes(1);
   expect(onValues.mock.calls[0][0].Awesome).toEqual('hello');
 });
+
+test('Input onChange is triggered when passing onChange as prop', () => {
+  const onChange = jest.fn();
+  const wrapper = mount(
+    <Form rules={{ Awesome: 'required' }}>
+      <Input name="Awesome" onChange={() => onChange()} />
+      <div className="submit" submit />
+    </Form>
+  );
+
+  wrapper
+    .find('input')
+    .simulate('change', { target: { name: 'Awesome', value: 'Hello World' } });
+
+  expect(onChange).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Hi @zackify,

Thank you for this great package. This pull request adds the possibility to have an onChange handler on the Input component. In the current version, onChange handlers are not invoked.

The onChange from the child component properties will be invoked if the method is passed as a property. I've also added a test for this.

Feel free to contact me if you have any questions.

Thanks,
Niels